### PR TITLE
Fix import of Final

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ dev =
   mypy == 0.910
   types-mock == 4.0.8
   # for linting
-  black == 21.9b0
+  black == 22.3.0
   flake8 == 4.0.1
   isort == 5.9.3
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
-
 from unittest.mock import Mock
+
 from synapse.api.errors import SynapseError
 from synapse.module_api import ModuleApi
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from mock import Mock
+from unittest.mock import Mock
 from synapse.api.errors import SynapseError
 from synapse.module_api import ModuleApi
 

--- a/username_from_threepid/__init__.py
+++ b/username_from_threepid/__init__.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 import re
 import string
-from typing import Any, Dict, Final, Optional
+from typing import Any, Dict, Optional
 
 import attr
 from synapse.module_api import ModuleApi
 from synapse.module_api.errors import ConfigError, SynapseError
+from typing_extensions import Final
 
 mxid_localpart_allowed_characters = frozenset(
     "_-./=" + string.ascii_lowercase + string.digits


### PR DESCRIPTION
We were importing from typing instead of typing_extensions, which broke compatibility with Python 3.7